### PR TITLE
Adding X-Registry-Config to build API for SSL based private repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-Docker Client [![Circle CI](https://circleci.com/gh/spotify/docker-client.png?style=badge)](https://circleci.com/gh/spotify/docker-client)
-=============
+# Docker Client [![Circle CI](https://circleci.com/gh/spotify/docker-client.png?style=badge)](https://circleci.com/gh/spotify/docker-client)
+
 
 This is a simple [Docker](https://github.com/dotcloud/docker) client written in Java.
 
-Usage
------
+**The latest docker-client release has only been tested on Docker API version 1.15. This client
+should work with older and newer versions of the Docker API, but your mileage may vary.**
+
+## Usage
+
 
 ```java
 // Create a client based on DOCKER_HOST and DOCKER_CERT_PATH env vars
@@ -106,8 +109,8 @@ Note that the connect timeout is also applied to acquiring a connection from the
 is exhausted and it takes too long to acquire a new connection for a request, we throw a
 `DockerTimeoutException` instead of just waiting forever on a connection becoming available.
 
-Maven
------
+## Maven
+
 
 Please note that in releases 2.7.6 and earlier, the default artifact was the shaded version.  When upgrading to version 2.7.7, you will need to include the shaded classifier if you relied on the shaded dependencies in the
 docker-client jar.
@@ -135,15 +138,15 @@ Shaded:
 
 **This is particularly important if you use Jersey 1.x in your project. To avoid conflicts with docker-client and Jersey 2.x, you will need to explicitly specify the shaded version above.**
 
-Testing
--------
+## Testing
+
 
 You can run tests on their own with `mvn test`. Note that the tests start and stop a large number of
 containers, so the list of containers you see with `docker ps -a` will start to get pretty long
 after many test runs. You may find it helpful to occassionally issue `docker rm $(docker ps -aq)`.
 
-Releasing
----------
+## Releasing
+
 
 Commits to the master branch will trigger our continuous integration agent to build the jar and
 release by uploading to Sonatype. If you are a project maintainer with the necessary credentials,

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>2.7.22</version>
+  <version>2.7.23-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/spotify/docker-client</connection>
     <developerConnection>scm:git:git@github.com:spotify/docker-client</developerConnection>
     <url>https://github.com/spotify/docker-client</url>
-    <tag>v2.7.22</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-client</artifactId>
-  <version>2.7.22-SNAPSHOT</version>
+  <version>2.7.22</version>
   <packaging>jar</packaging>
   <name>docker-client</name>
   <description>A docker client</description>
@@ -33,7 +33,7 @@
     <connection>scm:git:https://github.com/spotify/docker-client</connection>
     <developerConnection>scm:git:git@github.com:spotify/docker-client</developerConnection>
     <url>https://github.com/spotify/docker-client</url>
-    <tag>HEAD</tag>
+    <tag>v2.7.22</tag>
   </scm>
 
   <distributionManagement>

--- a/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
+++ b/src/main/java/com/spotify/docker/client/DefaultDockerClient.java
@@ -114,7 +114,7 @@ public class DefaultDockerClient implements DockerClient, Closeable {
 
   private static final String UNIX_SCHEME = "unix";
 
-  private static final String VERSION = "v1.12";
+  private static final String VERSION = "v1.15";
   private static final Logger log = LoggerFactory.getLogger(DefaultDockerClient.class);
 
   public static final long NO_TIMEOUT = 0;

--- a/src/main/java/com/spotify/docker/client/messages/Container.java
+++ b/src/main/java/com/spotify/docker/client/messages/Container.java
@@ -17,16 +17,16 @@
 
 package com.spotify.docker.client.messages;
 
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.util.Iterator;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
-
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 public class Container {
@@ -40,6 +40,40 @@ public class Container {
   @JsonProperty("Ports") private ImmutableList<PortMapping> ports;
   @JsonProperty("SizeRw") private Long sizeRw;
   @JsonProperty("SizeRootFs") private Long sizeRootFs;
+
+  /**
+   * This method returns port information the way that <code>docker ps</code> does:
+   * <code>0.0.0.0:5432->5432/tcp</code> or <code>6379/tcp</code>
+   *
+   * It should not be used to extract detailed information of ports. To do so,
+   * please refer to {@link com.spotify.docker.client.PortBinding}
+   *
+   * @see com.spotify.docker.client.PortBinding
+   *
+   * @return port information as docker ps does.
+   */
+  public String portsAsString() {
+    final StringBuilder sb = new StringBuilder();
+    if (this.ports != null) {
+      for (final PortMapping port : this.ports) {
+        if (sb.length() > 0) {
+          sb.append(", ");
+        }
+        if (port.ip != null) {
+          sb.append(port.ip).append(":");
+        }
+        if (port.publicPort > 0) {
+          sb.append(port.privatePort).append("->").append(port.publicPort);
+        } else {
+          sb.append(port.privatePort);
+        }
+        sb.append("/").append(port.type);
+      }
+    }
+
+    return sb.toString();
+  }
+
 
   public String id() {
     return id;
@@ -158,19 +192,19 @@ public class Container {
     public String getIp() {
       return ip;
     }
-    
+
     public int getPrivatePort() {
       return privatePort;
     }
-    
+
     public int getPublicPort() {
       return publicPort;
     }
-    
+
     public String getType() {
       return type;
     }
-    
+
     @Override
     public boolean equals(final Object o) {
       if (this == o) {

--- a/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
+++ b/src/test/java/com/spotify/docker/client/messages/ContainerTest.java
@@ -1,0 +1,41 @@
+package com.spotify.docker.client.messages;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.docker.client.ObjectMapperProvider;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ContainerTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	private ObjectMapper objectMapper;
+
+	@Before
+	public void setUp() throws Exception {
+		objectMapper = new ObjectMapperProvider().getContext(Container.class);
+	}
+
+	@Test
+	public void testLoadFromFixture() throws Exception {
+		Container container = objectMapper
+				.readValue(fixture("fixtures/container-ports-as-string.json"), Container.class);
+		assertThat(container.portsAsString(), is("0.0.0.0:80->88/tcp"));
+	}
+
+	private static String fixture(String filename) throws IOException {
+		return Resources.toString(Resources.getResource(filename), Charsets.UTF_8).trim();
+	}
+}

--- a/src/test/resources/fixtures/container-ports-as-string.json
+++ b/src/test/resources/fixtures/container-ports-as-string.json
@@ -1,0 +1,1 @@
+{"Id":"1009","Names": ["test", "ports"], "Image":"ports as string test", "Command": "test", "Created": 1, "Status": "testing", "Ports":[{"PrivatePort": 80, "PublicPort":88, "Type":"tcp", "IP":"0.0.0.0"}]}


### PR DESCRIPTION
Introduce a wrapper class to pass auth values and return formatted X-Registry-Config string.
The user/password/email and repository are base64 encoded and passed on the request header.

Notes - in order to get a local build, a couple of issues were found: 
a). Found that the ant version 1.8.2 is transitively pulled which causes findbugs to fail with a class not found exception - explicitly added 1.9.4 in the pom to correct this
b). Although exec has been added to the API in 1.15, exec inspect didn't get added until 1.16 so this causes failures in docker 1.3.2 (API V1.15)